### PR TITLE
ユーザー登録の電話番号の最大文字数を変更

### DIFF
--- a/app/assets/stylesheets/modules/_single_container.scss
+++ b/app/assets/stylesheets/modules/_single_container.scss
@@ -42,6 +42,9 @@
             border-color:$iconBlueColor;
           }
         }
+        .input__cellphone{
+          width: 290px;
+        }
         .input__name{
           width: 140px;
           &--block{

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -34,7 +34,7 @@ class SignupController < ApplicationController
     session[:email]                 = user_params[:email]
     session[:password]              = user_params[:password]
     session[:password_confirmation] = user_params[:password_confirmation]
-    session[:phone_number]          = "08012345678"
+    session[:phone_number]          = "8012345678"
     
     if user_params[:"birthday(1i)"] == "" || user_params[:"birthday(2i)"] == "" || user_params[:"birthday(3i)"] == ""
       session[:birthday]            = nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,5 +20,5 @@ class User < ApplicationRecord
   validates :first_name_kana,         presence: true
   validates :family_name_kana,        presence: true
   validates :birthday,                presence: true
-  validates :phone_number,            presence: true, length: {maximum: 11}
+  validates :phone_number,            presence: true, length: {maximum: 10}
 end

--- a/app/views/signup/step2.html.haml
+++ b/app/views/signup/step2.html.haml
@@ -13,7 +13,9 @@
         .label-wrapper
           = f.label :"携帯電話の番号"
           %br/
-        = f.text_field :phone_number, autofocus: true, placeholder: "携帯電話の番号を入力"
+        %span.num-top
+          +81
+        = f.text_field :phone_number, autofocus: true, class:"input__cellphone", placeholder: "携帯電話の番号を入力"
       %p.single-text.input-under__text
         本人確認のため、携帯電話のSMS(ショートメッセージサービス)を利用して認証を行います。
       .actions


### PR DESCRIPTION
# What
ユーザー登録時の携帯電話の最大桁数を11文字→10文字に変更

# Why
本番環境にて、11文字を受け付けない仕様になっており、修正に時間がかかるため、応急処置として、最大桁数を変更する